### PR TITLE
Add gitignore for PHP/IDE artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Ignore dependency directories
+vendor/
+
+# Ignore IDE/editor files
+.idea/
+.vscode/
+
+# Ignore logs
+*.log
+
+# Ignore OS generated files
+.DS_Store
+Thumbs.db
+
+# Ignore environment files
+.env
+
+# Ignore cache and build artifacts
+*.cache
+coverage/
+
+# Ignore node modules if any
+node_modules/


### PR DESCRIPTION
## Summary
- add `.gitignore` with typical patterns for PHP projects and editor files

## Testing
- `php -l index.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840deb941d8832699682444d82013b0