### PR TITLE
Fix path returned for sites dir

### DIFF
--- a/index.php
+++ b/index.php
@@ -203,14 +203,15 @@ function getSiteDir(): string
 {
     $drive = strtoupper(substr(PHP_OS, 0, 1));
     $rootDir = $drive . ':/laragon/etc/apache2/sites-enabled';
+
     if (strpos(strtolower($rootDir), 'c:') !== false) {
         $laragonDir = str_replace('D:', 'C:', $rootDir);
     } else {
         $laragonDir = $rootDir;
     }
 
-    if ($rootDir === false) {
-        throw new RuntimeException("Unable to determine the root directory.");
+    if ($laragonDir === false) {
+        throw new RuntimeException("Unable to determine the Laragon directory.");
     }
 
     if (!isset($_SERVER['SERVER_SOFTWARE']) || trim($_SERVER['SERVER_SOFTWARE']) === '') {
@@ -220,9 +221,9 @@ function getSiteDir(): string
     $serverSoftware = strtolower($_SERVER['SERVER_SOFTWARE']);
 
     if (strpos($serverSoftware, 'apache') !== false) {
-        return $rootDir;
+        return $laragonDir;
     } elseif (strpos($serverSoftware, 'nginx') !== false) {
-        return $rootDir;
+        return $laragonDir;
     }
 
     throw new InvalidArgumentException("Unsupported server type: " . htmlspecialchars($serverSoftware));


### PR DESCRIPTION
## Summary
- fix getSiteDir to return `$laragonDir` for Apache and Nginx

## Testing
- `php -l index.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840ded2ab908326b0b4ff54e982bb2f