### PR TITLE
Add configurable sendmail output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Our UI automatically detects any projects and directories within your root direc
 $ignore_dirs = array('.', '..', 'logs', 'access-logs', 'vendor', 'favicon_io', 'assets');
 ```
 
+5. Configure the mailbox directory by setting the `SENDMAIL_OUTPUT_DIR` environment variable or editing `config.php`.
+
 ```[php]
 $domainSuffix = '.test'; // Set this according to user preference or configuration
 

--- a/assets/inbox/inbox.php
+++ b/assets/inbox/inbox.php
@@ -1,4 +1,5 @@
 <?php
+        require_once __DIR__ . '/../../config.php';
 	/**
 	 * Application: Laragon | Server Index Inbox Page
 	 * Description: This is the main index page for the Laragon server, displaying server info and applications.
@@ -8,7 +9,7 @@
 	 */
 	
 	// Set the directory path (modify as needed)
-	const EML_FILE_PATH = 'D:/laragon/bin/sendmail/output/';
+        const EML_FILE_PATH = SENDMAIL_OUTPUT_DIR;
 	
 	function getEmailMetadata($filename) {
 		$content = file_get_contents(EML_FILE_PATH . $filename);

--- a/assets/inbox/open_email.php
+++ b/assets/inbox/open_email.php
@@ -1,9 +1,7 @@
 <?php
-// Define potential paths
-	$emailFilePaths = [
-		'C:/laragon/bin/sendmail/output/',
-		'D:/laragon/bin/sendmail/output/',
-	];
+        require_once __DIR__ . '/../../config.php';
+// Directory containing the email files
+        $emailFilePaths = [SENDMAIL_OUTPUT_DIR];
 	
 	function findEmailFile($filename, $paths)
 	{

--- a/config.php
+++ b/config.php
@@ -1,0 +1,6 @@
+<?php
+// Configuration for Laragon Dashboard
+// Define the directory where sendmail stores outbound emails.
+// This can be overridden using the SENDMAIL_OUTPUT_DIR environment variable.
+
+define('SENDMAIL_OUTPUT_DIR', rtrim(getenv('SENDMAIL_OUTPUT_DIR') ?: 'D:/laragon/bin/sendmail/output/', '/\\') . '/');


### PR DESCRIPTION
## Summary
- make sendmail location configurable via new `config.php`
- reference `SENDMAIL_OUTPUT_DIR` from `inbox.php` and `open_email.php`
- document SENDMAIL_OUTPUT_DIR setup in README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840deb88abc83268e60559f4ef982f8