### PR TITLE
Improve server info layout and add project search

### DIFF
--- a/assets/inbox/inbox.php
+++ b/assets/inbox/inbox.php
@@ -163,8 +163,7 @@
       }
 
       .tab:hover,
-      .tab:focus,
-      {
+      .tab:focus {
           background-color: #16437E;
           color: #ffffff;
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -71,6 +71,12 @@ a {
     margin: 10px;
 }
 
+/* More compact layout for server info */
+.server-overview {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    grid-auto-rows: 50px;
+}
+
 
 .wrapper {
     display: grid;

--- a/index.php
+++ b/index.php
@@ -402,6 +402,13 @@ $activeTab = $_GET['tab'] ?? 'servers';
             var lang = $(this).val();
             window.location.href = "?lang=" + lang;
         });
+
+        $('#project-search').on('input', function() {
+            var q = $(this).val();
+            $.get('project_search.php', {q: q}, function(data) {
+                $('#project-list').html(data);
+            });
+        });
     });
 
     function fetchServerVitals() {
@@ -804,7 +811,7 @@ foreach ($langFiles as $file) {
                 <div class="header__search"><?php echo $translations['breadcrumb_server_servers'] ?? 'My Development Server Servers & Applications'; ?></div>
                 <div class="header__avatar"><?php echo $translations['welcome_back'] ?? 'Welcome Back!'; ?></div>
             </header>
-            <div class="main-overview">
+            <div class="main-overview server-overview">
                 <div class="overviewcard4">
                     <div class="overviewcard_icon"></div>
                     <div class="overviewcard_info"><img src="assets/Server.png" style="width:64px;"></div>
@@ -839,7 +846,7 @@ foreach ($langFiles as $file) {
                     </div>
                 </div>
             </div>
-            <div class="main-overview">
+            <div class="main-overview server-overview">
                 <div class="overviewcard">
                     <div class="overviewcard_icon">MySQL</div>
                     <div class="overviewcard_info">
@@ -894,10 +901,13 @@ if (!$link) {
                 </div> -->
             </div>
 
-            <div class="main-overview wrapper">
+            <input type="text" id="project-search" placeholder="Search projects..." style="margin:10px 0;padding:5px;width:100%;max-width:400px;">
+
+            <div id="project-list" class="main-overview wrapper">
                 <?php
 $ignored = ['favicon_io'];
 $folders = array_filter(glob('*'), 'is_dir');
+sort($folders, SORT_NATURAL | SORT_FLAG_CASE);
 
 if ($laraconfig['SSLEnabled'] == 0 || $laraconfig['Port'] == 80) {
     $url = 'http';
@@ -978,7 +988,7 @@ foreach ($folders as $host) {
                 <div class="header__search"><?php echo $translations['breadcrumb_server_vitals'] ?? 'My Development Server Vitals'; ?></div>
                 <div class="header__avatar"><?php echo $translations['welcome_back'] ?? 'Welcome Back!'; ?></div>
             </header>
-            <div class="container mt-5" style="width: 1440px!important;background-color: #f8f9fa;padding: 20px;border-radius: 5px;color=#000000">
+            <div class="container mt-5" style="width: 1440px!important;background-color: #f8f9fa;padding: 20px;border-radius: 5px;color: #000000;">
                 <h1 style="text-align: center;color: #000000">Server's Vitals</h1>
 
                 <div class="row">

--- a/project_search.php
+++ b/project_search.php
@@ -1,0 +1,73 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+$ignored = ['favicon_io'];
+$folders = array_filter(glob('*'), 'is_dir');
+sort($folders, SORT_NATURAL | SORT_FLAG_CASE);
+
+$laraconfig = @parse_ini_file('../usr/laragon.ini');
+if ($laraconfig['SSLEnabled'] == 0 || ($laraconfig['Port'] ?? 80) == 80) {
+    $url = 'http';
+} else {
+    $url = 'https';
+}
+
+$ignore_dirs = ['.', '..', 'logs', 'access-logs', 'vendor', 'favicon_io', 'ablepro-90', 'assets'];
+$q = isset($_GET['q']) ? strtolower($_GET['q']) : '';
+
+foreach ($folders as $host) {
+    if (in_array($host, $ignore_dirs) || !is_dir($host)) {
+        continue;
+    }
+    if ($q && stripos($host, $q) === false) {
+        continue;
+    }
+
+    $admin_link = '';
+    $app_name = '';
+    $avatar = '';
+
+    switch (true) {
+        case (file_exists($host . '/core') || file_exists($host . '/web/core')):
+            $app_name = ' Drupal ';
+            $avatar = 'assets/Drupal.svg';
+            $admin_link = '<a href="' . $url . '://' . htmlspecialchars($host) . '.local/user" target="_blank"><small style="font-size: 8px; color: #cccccc;">' . $app_name . '</small><br>Admin</a>';
+            break;
+        case file_exists($host . '/wp-admin'):
+            $app_name = ' Wordpress ';
+            $avatar = 'assets/Wordpress.png';
+            $admin_link = '<a href="' . $url . '://' . htmlspecialchars($host) . '.local/wp-admin" target="_blank"><small style="font-size: 8px; color: #cccccc;">' . $app_name . '</small><br>Admin</a>';
+            break;
+        case file_exists($host . '/administrator'):
+            $app_name = ' Joomla ';
+            $avatar = 'assets/Joomla.png';
+            $admin_link = '<a href="' . $url . '://' . htmlspecialchars($host) . '.local/administrator" target="_blank"><small style="font-size: 8px; color: #cccccc;">' . $app_name . '</small><br>Admin</a>';
+            break;
+        case file_exists($host . '/public/index.php') && is_dir($host . '/app') && file_exists($host . '/.env'):
+            $app_name = ' Laravel ';
+            $avatar = 'assets/Laravel.png';
+            $admin_link = '';
+            break;
+        case file_exists($host . '/bin/console'):
+            $app_name = ' Symfony ';
+            $avatar = 'assets/Symfony.png';
+            $admin_link = '<a href="' . $url . '://' . htmlspecialchars($host) . '.local/admin" target="_blank"><small style="font-size: 8px; color: #cccccc;">' . $app_name . '</small><br>Admin</a>';
+            break;
+        case (file_exists($host . '/') && is_dir($host . '/app.py') && is_dir($host . '/static') && file_exists($host . '/.env')):
+            $app_name = ' Python ';
+            $avatar = 'assets/Python.png';
+            $admin_link = '<a href="' . $url . '://' . htmlspecialchars($host) . '.local/Public" target="_blank"><small style="font-size: 8px; color: #cccccc;">' . $app_name . '</small><br>Public Folder</a>';
+            break;
+        case file_exists($host . '/bin/cake'):
+            $app_name = ' CakePHP ';
+            $avatar = 'assets/CakePHP.png';
+            $admin_link = '<a href="' . $url . '://' . htmlspecialchars($host) . '.local/admin" target="_blank"><small style="font-size: 8px; color: #cccccc;">' . $app_name . '</small><br>Admin</a>';
+            break;
+        default:
+            $admin_link = '';
+            $avatar = 'assets/Unknown.png';
+            break;
+    }
+
+    echo '<div class="overviewcard_sites"><div class="overviewcard_avatar"><img src="' . $avatar . '" style="width:20px; height:20px;"></div><div class="overviewcard_icon"><a href="' . $url . '://' . htmlspecialchars($host) . '.local">' . htmlspecialchars($host) . '</a></div><div class="overviewcard_info">' . $admin_link . '</div></div>';
+}


### PR DESCRIPTION
## Summary
- shrink server info cards with new `server-overview` style
- implement AJAX project search via `project_search.php`
- add search box to dashboard and update JS

## Testing
- `php -l index.php`
- `php -l assets/inbox/inbox.php`
- `php -l assets/inbox/open_email.php`
- `php -l server_vitals.php`
- `php -l assets/WindowsUptime.class.php`
- `php -l project_search.php`
- `php -l config.php`


------
https://chatgpt.com/codex/tasks/task_e_6853504708708326a3b540bb23f5c40f